### PR TITLE
add XYG3-type double hybrids (xDH)

### DIFF
--- a/XYG3TypeDoubleHybrids/test.inp
+++ b/XYG3TypeDoubleHybrids/test.inp
@@ -1,0 +1,28 @@
+
+*xyz 0 1
+N  0.0       0.0       0.108827
+H  0.0       0.947455 -0.253931
+H  0.820520 -0.473727 -0.253931
+H -0.820520 -0.473727 -0.253931
+*
+%pal nprocs 4 end
+%maxcore 1000
+
+%compound "xdh.cmp"
+  with
+    xc = "xyg3";
+    basis = "def2-svp";
+    auxbas = "def2-svp/c";
+    # optional params
+    # dlpno = "true";
+end
+
+# EDH: -56.459
+
+# for xygjos
+#%compound "xdh_scs.cmp"
+#  with
+#    xc = "xygjos";
+#    basis = "def2-svp";
+#    auxbas = "def2-svp/c";
+#end

--- a/XYG3TypeDoubleHybrids/xdh.cmp
+++ b/XYG3TypeDoubleHybrids/xdh.cmp
@@ -1,0 +1,66 @@
+#
+# XYG3 with RI-MP2.
+#
+# Final energy : EDH
+#
+Variable xc = "xyg3";
+Variable basis = "def2-svp";
+Variable auxbas = "def2-svp/c";
+Variable dlpno = "false";
+
+Variable acm[3] ;
+Variable scalldac = 0.6789;
+Variable pt2_coeff = 0.3211;
+Variable Enscf;
+Variable Ept2;
+Variable Edh;
+
+if (xc = "xyg3") then
+ pt2_coeff = 0.3211;
+ acm[0] = 0.8033;
+ acm[1] = 0.2107;
+ acm[2] = 0.6789;
+ scalldac = 0.6789;
+endif
+
+New_Step
+! b3lyp_g &{basis}
+! noautostart
+Step_End
+Alias scf
+
+Read_Geom scf
+Read_Mos scf
+New_Step
+! b3lyp_g &{basis}
+!  nopop 
+%scf 
+ maxiter 1 
+ ignoreconv true
+end
+%method
+ Functional b3lyp_g
+ ACM = &{acm[0]}, &{acm[1]},&{acm[2]}
+ ScalLDAC = &{scalldac}
+end
+Step_End
+Alias nscf
+
+Read_Geom scf
+Read_Mos scf
+New_Step
+! RI-MP2 &{basis} &{auxbas}
+! noiter nopop
+! nofrozencore
+%mp2
+ dlpno &{dlpno}
+end
+Step_End
+Alias pt2
+
+read Enscf = SCF_ENERGY[nscf];
+read Ept2 = MP2_CORR_ENERGY[pt2];
+
+Edh = (Enscf + Ept2*pt2_coeff);
+
+End

--- a/XYG3TypeDoubleHybrids/xdh_scs.cmp
+++ b/XYG3TypeDoubleHybrids/xdh_scs.cmp
@@ -1,0 +1,75 @@
+#
+# XYGJ-OS with RI-MP2
+#
+# Final energy : EDH
+#
+
+Variable xc = "xyg3";
+Variable basis = "def2-svp";
+Variable auxbas = "def2-svp/c";
+Variable dlpno = "false";
+
+Variable acm[3] ;
+Variable scalldac;
+Variable pt2_coeff;
+Variable ss = 1.0;
+Variable os = 1.0;
+Variable Enscf;
+Variable Ept2;
+Variable Edh;
+
+if (xc = "xygjos") then
+ pt2_coeff = 0.4364;
+ ss = 0.0;
+ acm[0] = 0.7731;
+ acm[1] = 0.0 ;
+ acm[2] = 0.2754;
+ scalldac = 0.5063; 
+endif
+
+New_Step
+! b3lyp_g &{basis}
+! noautostart
+Step_End
+Alias scf
+
+Read_Geom scf
+Read_Mos scf
+New_Step
+! b3lyp_g &{basis}
+!  nopop 
+%scf 
+ maxiter 1 
+ ignoreconv true
+end
+%method
+ Functional b3lyp_g
+ ACM = &{acm[0]}, &{acm[1]},&{acm[2]}
+ ScalLDAC = &{scalldac}
+end
+Step_End
+Alias nscf
+
+Read_Geom scf
+Read_Mos scf
+New_Step
+! RI-MP2 &{basis} &{auxbas}
+! noiter nopop
+! nofrozencore
+%mp2
+ dlpno &{dlpno}
+ doscs true
+ ps &{os}
+ pt &{ss}
+end
+Step_End
+Alias pt2
+
+read Enscf = SCF_ENERGY[nscf];
+read Ept2 = MP2_CORR_ENERGY[pt2];
+
+Edh = (Enscf + Ept2*pt2_coeff);
+#print("%s Results", xc);
+#print("Total energy: %lf", Edh);
+
+End


### PR DESCRIPTION
Here are two scripts for xDH single point job: 
* xdh.cmp for functionals without SCS-MP2, like XYG3. 
* xdh_scs.cmp for functionals with SCS-MP2 or OS-MP2, like XYGJ-OS. I may add other ones later, like XYG7.