### PR TITLE
Additional section in the README.md to ensure users use the appropriate command blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Compound scripts allow the user to automate complicated workflows directly withi
 
 Also, a complicated workflow can be run in a single computation---no need to wait for finished jobs and resubmissions.
 
+## Special Formatting and file extention note
+1. While the extention of your input files can be anything, It's recommedned to keep them to the traditional ".inp" (input) or ".cmp" (compound) extentions.
+2. While not shown in any of the following examples, a compound script REQUIRES the `%Compound` block to come before any variables. Additionally, if you desire your job to be multi-threaded you will need the `%maxcore` and `%Pal NPROCSHARED` blocks to be above the `%Compound` block
+3. Note the `%maxcore` and `%Pal NPROCSHARED` blocks can only be supplied once. All subsequent New_Step sections will re-use the same memory and number of CPUs. 
 
 ## How do I contribute?
 


### PR DESCRIPTION
Included a section on formatting to make it more clear for users how to use command input files.

I updated a section in the README.md to let users know that a Compound ORCA input file can be any extension. I've seen on the net examples with both .inp and .cmp but it's never stated explicitly that these don't really matter. A user could use any extension. But for convention we use .inp for single jobs and .cmp for compound jobs.  

Additionally I added a section that instructs a user that the `%compound` block needs to be above any variables, and that the `%maxcore` and `%pal nprocshared` blocks need to be above the `%compound` block. I was unable to get the example .cmp files to work on any of my clusters or local machine without these blocks being present in that order. 

As written the examples do not run. 

This additional part of the README should be helpful to users.